### PR TITLE
create /dff before writing file. So empty sd card would work

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -393,6 +393,7 @@ void ReadStreamedDff(int socket)
 	int32_t size = ntohl(n_size);
 	printf("About to read %d bytes of dff data!", size);
 
+	mkdir("sd:/dff", 0777);
 	FILE* file = fopen("sd:/dff/test.dff", "wb"); // TODO: Change!
 
 	if (file == NULL)


### PR DESCRIPTION
This fix a crash with empty sd cards
